### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/slidesharewp.php
+++ b/syntax/slidesharewp.php
@@ -51,7 +51,7 @@ class syntax_plugin_slidesharewp_slidesharewp extends DokuWiki_Syntax_Plugin {
      * @param Doku_Handler    $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, Doku_Handler &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         $pm = preg_match_all('/\[slideshare id=(.+?)&doc=(.+?)\]/', $match, $result);
         $id = $result[1][0];
         $doc = $result[2][0];
@@ -66,7 +66,7 @@ class syntax_plugin_slidesharewp_slidesharewp extends DokuWiki_Syntax_Plugin {
      * @param array          $data      The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, Doku_Renderer &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
         list($id, $doc) = $data;
         $id = urlencode($id);


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
